### PR TITLE
Vaadin license checker excluded in the vulcanize processs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,7 +28,7 @@ var historyApiFallback = require('connect-history-api-fallback');
 var packageJson = require('./package.json');
 var crypto = require('crypto');
 var ensureFiles = require('./tasks/ensure-files.js');
-var polybuild = require('polybuild');
+var polyclean = require('polyclean');
 
 // var ghPages = require('gulp-gh-pages');
 
@@ -172,10 +172,15 @@ gulp.task('html', function() {
 // Vulcanize granular configuration
 gulp.task('vulcanize', function() {
   return gulp.src('app/elements/elements.html')
-    .pipe(polybuild({
-      maximumCrush: true,
-      suffix: ''
+    .pipe($.vulcanize({
+      stripComments: true,
+      inlineCss: true,
+      inlineScripts: true,
+      stripExcludes: ['app/bower_components/vaadin-license-checker/vaadin-license-checker.html']
     }))
+    .pipe(polyclean.cleanCss())
+    .pipe(polyclean.uglifyJs())
+    .pipe($.crisper())
     .pipe(gulp.dest(dist('elements')))
     .pipe($.size({
       title: 'vulcanize'

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "gulp-autoprefixer": "^3.1.0",
     "gulp-cache": "^0.4.0",
     "gulp-changed": "^1.0.0",
+    "gulp-crisper": "^1.0.0",
     "gulp-gh-pages": "^0.5.4",
     "gulp-html-extract": "^0.1.0",
     "gulp-if": "^2.0.0",
@@ -22,10 +23,12 @@
     "gulp-size": "^2.0.0",
     "gulp-uglify": "^1.2.0",
     "gulp-useref": "^2.1.0",
+    "gulp-vulcanize": "^6.0.0",
     "merge-stream": "^1.0.0",
-    "polybuild": "^1.1.0",
+    "polyclean": "^1.3.1",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",
+    "vulcanize": ">= 1.4.2",
     "web-component-tester": "^4.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Excluding vaadin-license-checker from the build further reduces the size by 40kb
