### PR TITLE
Add missing iron-icons dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "vaadin-charts": "^3.1.0",
     "vaadin-pouchdb": "manolo/vaadin-pouchdb#em",
     "iron-a11y-keys": "polymerelements/iron-a11y-keys#^1.0.5",
+    "iron-icons": "^1.2.0",
     "paper-header-panel": "polymerelements/paper-header-panel#^1.1.6",
     "paper-toolbar": "polymerelements/paper-toolbar#^1.1.4",
     "app-route": "polymerelements/app-route#^0.9.1",


### PR DESCRIPTION
Clean bower install will say that iron-icons can't be found.