### PR TITLE
Use master version of vaadin-license-checker for fixed style scoping

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,8 @@
     "paper-dialog": "polymerelements/paper-dialog#^1.0.4",
     "iron-pages": "polymerelements/iron-pages#^1.0.7",
     "paper-toast": "polymerelements/paper-toast#^1.3.0",
-    "iron-media-query": "^1.0.8"
+    "iron-media-query": "^1.0.8",
+    "vaadin-license-checker": "vaadin/license-checker#master"
   },
   "devDependencies": {
     "web-component-tester": "^4.0.0"


### PR DESCRIPTION
License checker css was scoped in master version https://github.com/vaadin/license-checker/pull/23 Use the master version so that grid's header is not changed