### PR TITLE
Replace app-toolbar with custom one using Lumo dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,8 @@
       flex-direction: column;
       margin: 0;
       height: 100%;
-      background: hsl(214, 27%, 26%);
+      background: #fff;
+      color: #000;
       font-family: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", Ubuntu, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
       -webkit-tap-highlight-color: transparent;
       -webkit-font-smoothing: antialiased;

--- a/src/content-panel.html
+++ b/src/content-panel.html
@@ -20,12 +20,12 @@
 
       #history-panel {
         border-left: 1px solid #ddd;
-        box-shadow: rgba(0, 0, 0, 0.2) 6px 0px 16px -10px inset;
+        box-shadow: var(--lumo-shade-50pct) 6px 0 16px -10px inset;
         z-index: 1;
       }
 
       #history-panel[tablet] {
-        box-shadow: rgba(0, 0, 0, 0.2) 0px 6px 16px -10px inset;
+        box-shadow: var(--lumo-shade-50pct) 0 6px 16px -10px inset;
       }
 
     </style>

--- a/src/nav-bar.html
+++ b/src/nav-bar.html
@@ -1,0 +1,71 @@
+<link rel="import" href="../bower_components/polymer/polymer-element.html">">
+
+<link rel="import" href="../bower_components/vaadin-button/vaadin-button.html">
+<link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
+<link rel="import" href="../bower_components/vaadin-lumo-styles/spacing.html">
+<link rel="import" href="../bower_components/vaadin-lumo-styles/typography.html">
+
+<link rel="import" href="data/store.html">
+
+<dom-module id="nav-bar">
+  <template>
+    <style include="lumo-color">
+      :host {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        box-sizing: border-box;
+        width: 100%;
+        height: 64px;
+        padding: 0 var(--lumo-space-m);
+      }
+
+      h1 {
+        margin-right: auto;
+        font-size: var(--lumo-font-size-xl);
+        font-weight: 300;
+      }
+
+      vaadin-button {
+        margin-left: var(--lumo-space-m);
+        flex: none;
+        text-transform: uppercase;
+      }
+    </style>
+
+    <h1>Expense Manager</h1>
+
+    <vaadin-button on-click="_showInfoDialog" theme="small">Info</vaadin-button>
+    <vaadin-button on-click="_logout" theme="small">Logout</vaadin-button>
+
+  </template>
+
+  <script>
+    (function() {
+      /**
+       * @memberof ExpenseManager
+       */
+      class NavBarElement extends ExpenseManager.ReduxMixin(Polymer.Element) {
+        static get is() {
+          return 'nav-bar';
+        }
+
+        _showInfoDialog() {
+          this.dispatch('showInfoDialog');
+        }
+
+        _logout() {
+          this.dispatch('logout');
+        }
+      }
+
+      customElements.define(NavBarElement.is, NavBarElement);
+
+      /**
+       * @namespace ExpenseManager
+       */
+      window.ExpenseManager = window.ExpenseManager || {};
+      ExpenseManager.NavBarElement = NavBarElement;
+    })();
+  </script>
+</dom-module>

--- a/src/overview-page.html
+++ b/src/overview-page.html
@@ -1,7 +1,10 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/polymer/lib/mixins/gesture-event-listeners.html">
 <link rel="import" href="../bower_components/vaadin-button/vaadin-button.html">
-<link rel="import" href="../bower_components/app-layout/app-layout.html">
+<link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
+<link rel="import" href="../bower_components/app-layout/app-header-layout/app-header-layout.html">
+<link rel="import" href="../bower_components/app-layout/app-header/app-header.html">
+<link rel="import" href="nav-bar.html">
 <link rel="import" href="expense-editor.html">
 <link rel="import" href="info-dialog.html">
 <link rel="import" href="content-panel.html">
@@ -11,26 +14,9 @@
 
 <dom-module id="overview-page">
   <template>
-    <style>
+    <style include="lumo-color">
       :host {
         display: block;
-      }
-
-      app-header-layout {
-        background-color: var(--primary-background-color);
-      }
-
-      app-header {
-        background-color: hsl(214, 27%, 26%);
-        --app-header-content: {
-          padding: 0 24px;
-        }
-      }
-
-      app-toolbar h1 {
-        color: var(--light-primary-color);
-        font-weight: 300;
-        font-size: var(--lumo-font-size-xl);
       }
 
       .content[phone] {
@@ -45,12 +31,12 @@
 
       #filters-toolbar[phone] {
         width: auto;
-        box-shadow: rgba(0, 0, 0, 0.2) 0px -10px 6px -10px inset;
+        box-shadow: var(--lumo-shade-50pct) 0 -10px 6px -10px inset;
       }
 
       #filters-toolbar {
         width: 300px;
-        box-shadow: inset -4px 0 16px -9px rgba(0, 0, 0, 0.5);
+        box-shadow: inset -4px 0 16px -9px var(--lumo-shade-50pct);
       }
 
       @media (max-width: 1124px) {
@@ -79,33 +65,11 @@
           transform: rotate(-360deg);
         }
       }
-
-      vaadin-button {
-        margin: 0 var(--lumo-space-s);
-        color: var(--lumo-primary-contrast-color);
-        text-transform: uppercase;
-      }
-
-      @media (max-width: 900px) {
-        app-toolbar {
-          --app-toolbar-content: {
-            padding: 0 6px 0 16px;
-          }
-        }
-        app-toolbar h1 {
-          font-size: 20px;
-        }
-      }
-
     </style>
 
-    <app-header-layout fullbleed theme="dark">
+    <app-header-layout fullbleed>
       <app-header slot="header" fixed condenses>
-        <app-toolbar>
-          <h1 main-title>Expense Manager</h1>
-          <vaadin-button on-tap="_showInfoDialog" theme="tertiary small">Info</vaadin-button>
-          <vaadin-button on-tap="_logout" theme="tertiary small">Logout</vaadin-button>
-        </app-toolbar>
+        <nav-bar theme="dark"></nav-bar>
       </app-header>
 
       <div class="content" phone$="[[_phone]]" tablet$="[[_tablet]]">
@@ -150,14 +114,6 @@
              */
             _tablet: Boolean
           };
-        }
-
-        _showInfoDialog() {
-          this.dispatch('showInfoDialog');
-        }
-
-        _logout() {
-          this.dispatch('logout');
         }
       }
 


### PR DESCRIPTION
Connected to #62 

The `app-toolbar` is just a bunch of styles and the tag name is not hardcoded in neither `app-header` nor `app-header-layout` so this is supposed to slightly reduce bundle size.

Another benefit here is demonstrating the `theme="dark"` and cleanup styles for `h1` and buttons so that the content is still readable when removing that attribute.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/expense-manager-demo/76)
<!-- Reviewable:end -->
