### PR TITLE
Move phone and tablet properties to ResponsiveMixin

### DIFF
--- a/src/content-panel.html
+++ b/src/content-panel.html
@@ -1,6 +1,8 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="history-panel.html">
 <link rel="import" href="expenses-list.html">
+<link rel="import" href="responsive-mixin.html">
+
 <dom-module id="content-panel">
   <template>
     <style>
@@ -36,30 +38,11 @@
     (function() {
       /**
        * @memberof ExpenseManager
+       * @mixes ExpenseManager.ResponsiveMixin
        */
-      class ContentPanelElement extends Polymer.Element {
+      class ContentPanelElement extends ExpenseManager.ResponsiveMixin(Polymer.Element) {
         static get is() {
           return 'content-panel';
-        }
-
-        static get properties() {
-          return {
-            /**
-             * Whether the screen matches the tablet breakpoint.
-             */
-            tablet: {
-              type: Boolean,
-              reflectToAttribute: true
-            },
-
-            /**
-             * Whether the screen matches the phone breakpoint.
-             */
-            phone: {
-              type: Boolean,
-              reflectToAttribute: true
-            }
-          };
         }
       }
 

--- a/src/expense-editor.html
+++ b/src/expense-editor.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
-<link rel="import" href="../bower_components/polymer/lib/mixins/gesture-event-listeners.html">
 <link rel="import" href="../bower_components/iron-a11y-keys/iron-a11y-keys.html">
 <link rel="import" href="../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../bower_components/vaadin-button/vaadin-button.html">
@@ -112,7 +111,7 @@
       /**
        * @memberof ExpenseManager
        */
-      class ExpenseEditorElement extends ExpenseManager.ReduxMixin(Polymer.GestureEventListeners(Polymer.Element)) {
+      class ExpenseEditorElement extends ExpenseManager.ReduxMixin(Polymer.Element) {
         static get is() {
           return 'expense-editor';
         }

--- a/src/expenses-list.html
+++ b/src/expenses-list.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
-<link rel="import" href="../bower_components/polymer/lib/mixins/gesture-event-listeners.html">
 <link rel="import" href="../bower_components/vaadin-grid/vaadin-grid.html">
 <link rel="import" href="../bower_components/vaadin-grid/vaadin-grid-sorter.html">
 <link rel="import" href="../bower_components/paper-fab/paper-fab.html">
@@ -133,14 +132,14 @@
       </vaadin-grid-column>
 
     </vaadin-grid>
-    <paper-fab icon="expense-manager:add" on-tap="_showExpenseEditor" id="add-button"></paper-fab>
+    <paper-fab icon="expense-manager:add" on-click="_showExpenseEditor" id="add-button"></paper-fab>
   </template>
   <script>
     (function() {
       /**
        * @memberof ExpenseManager
        */
-      class ExpensesListElement extends ExpenseManager.ReduxMixin(Polymer.GestureEventListeners(Polymer.Element)) {
+      class ExpensesListElement extends ExpenseManager.ReduxMixin(Polymer.Element) {
         static get is() {
           return 'expenses-list';
         }

--- a/src/filters-toolbar.html
+++ b/src/filters-toolbar.html
@@ -1,12 +1,11 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
-<link rel="import" href="../bower_components/polymer/lib/mixins/gesture-event-listeners.html">
-<link rel="import" href="../bower_components/polymer/lib/mixins/gesture-event-listeners.html">
 <link rel="import" href="../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
 <link rel="import" href="../bower_components/vaadin-lumo-styles/sizing.html">
 <link rel="import" href="../bower_components/vaadin-lumo-styles/spacing.html">
 <link rel="import" href="../bower_components/vaadin-button/vaadin-button.html">
 <link rel="import" href="search-filters.html">
+<link rel="import" href="responsive-mixin.html">
 <link rel="import" href="data/store.html">
 <link rel="import" href="icons.html">
 
@@ -95,8 +94,9 @@
     (function() {
       /**
        * @memberof ExpenseManager
+       * @mixes ExpenseManager.ResponsiveMixin
        */
-      class FiltersToolbarElement extends ExpenseManager.ReduxMixin(Polymer.GestureEventListeners(Polymer.Element)) {
+      class FiltersToolbarElement extends ExpenseManager.ReduxMixin(ExpenseManager.ResponsiveMixin(Polymer.Element)) {
         static get is() {
           return 'filters-toolbar';
         }
@@ -127,22 +127,6 @@
               type: Number,
               statePath: ExpenseManager.select.appliedFilters
             },
-
-            /**
-             * Whether the screen matches the tablet breakpoint.
-             */
-            tablet: {
-              type: Boolean,
-              reflectToAttribute: true
-            },
-
-            /**
-             * Whether the screen matches the phone breakpoint.
-             */
-            phone: {
-              type: Boolean,
-              reflectToAttribute: true
-            }
           };
         }
 

--- a/src/history-panel.html
+++ b/src/history-panel.html
@@ -7,6 +7,7 @@
 <link rel="import" href="moment-js.html">
 <link rel="import" href="data/store.html">
 
+<link rel="import" href="responsive-mixin.html">
 <link rel="import" href="shared-styles.html">
 
 <dom-module id="history-panel">
@@ -68,8 +69,9 @@
     (function() {
       /**
        * @memberof ExpenseManager
+       * @mixes ExpenseManager.ResponsiveMixin
        */
-      class HistoryPanelElement extends ExpenseManager.ReduxMixin(Polymer.Element) {
+      class HistoryPanelElement extends ExpenseManager.ReduxMixin(ExpenseManager.ResponsiveMixin(Polymer.Element)) {
 
         static get is() {
           return 'history-panel';
@@ -83,22 +85,6 @@
             totalOwed: {
               type: Number,
               statePath: ExpenseManager.select.total
-            },
-
-            /**
-             * Whether the screen matches the tablet breakpoint.
-             */
-            tablet: {
-              type: Boolean,
-              reflectToAttribute: true
-            },
-
-            /**
-             * Whether the screen matches the phone breakpoint.
-             */
-            phone: {
-              type: Boolean,
-              reflectToAttribute: true
             }
           };
         }

--- a/src/login-page.html
+++ b/src/login-page.html
@@ -1,11 +1,10 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
-<link rel="import" href="../bower_components/polymer/lib/mixins/gesture-event-listeners.html">
-
+<link rel="import" href="../bower_components/iron-a11y-keys/iron-a11y-keys.html">
+<link rel="import" href="../bower_components/vaadin-button/vaadin-button.html">
+<link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
 <link rel="import" href="../bower_components/vaadin-text-field/vaadin-text-field.html">
 <link rel="import" href="../bower_components/vaadin-text-field/vaadin-password-field.html">
-<link rel="import" href="../bower_components/vaadin-button/vaadin-button.html">
-<link rel="import" href="../bower_components/iron-a11y-keys/iron-a11y-keys.html">
-<link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
+
 <link rel="import" href="data/store.html">
 
 <dom-module id="login-page">
@@ -82,7 +81,7 @@
     <div class="login">
       <vaadin-text-field value={{username}} label="Username" name="username"></vaadin-text-field>
       <vaadin-password-field value="{{password}}" label="Password" name="password"></vaadin-password-field>
-      <vaadin-button theme="primary" id="login-button" on-tap="_logIn">Login</vaadin-button>
+      <vaadin-button theme="primary" id="login-button" on-click="_logIn">Login</vaadin-button>
     </div>
     <div id="footer">
       <span class="fork-me">
@@ -99,7 +98,7 @@
       /**
        * @memberof ExpenseManager
        */
-      class LoginPageElement extends ExpenseManager.ReduxMixin(Polymer.GestureEventListeners(Polymer.Element)) {
+      class LoginPageElement extends ExpenseManager.ReduxMixin(Polymer.Element) {
         static get is() {
           return 'login-page';
         }

--- a/src/overview-page.html
+++ b/src/overview-page.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
-<link rel="import" href="../bower_components/polymer/lib/mixins/gesture-event-listeners.html">
 <link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
 <link rel="import" href="../bower_components/app-layout/app-header-layout/app-header-layout.html">
 <link rel="import" href="../bower_components/app-layout/app-header/app-header.html">
@@ -9,6 +8,7 @@
 <link rel="import" href="content-panel.html">
 <link rel="import" href="filters-toolbar.html">
 <link rel="import" href="data/store.html">
+<link rel="import" href="responsive-mixin.html">
 <link rel="import" href="../bower_components/iron-media-query/iron-media-query.html">
 
 <dom-module id="overview-page">
@@ -18,7 +18,7 @@
         display: block;
       }
 
-      .content[phone] {
+      :host([phone]) .content {
         flex-direction: column;
       }
 
@@ -54,20 +54,20 @@
         <nav-bar theme="dark"></nav-bar>
       </app-header>
 
-      <div class="content" phone$="[[_phone]]" tablet$="[[_tablet]]">
-        <filters-toolbar phone="[[_phone]]" tablet="[[_tablet]]"></filters-toolbar>
-        <content-panel phone="[[_phone]]" tablet="[[_tablet]]"></content-panel>
+      <div class="content">
+        <filters-toolbar phone="[[phone]]" tablet="[[tablet]]"></filters-toolbar>
+        <content-panel phone="[[phone]]" tablet="[[tablet]]"></content-panel>
       </div>
     </app-header-layout>
 
     <iron-media-query
       query="(max-width: 900px)"
-      query-matches="{{_phone}}">
+      query-matches="{{phone}}">
     </iron-media-query>
 
     <iron-media-query
       query="(max-width: 1124px)"
-      query-matches="{{_tablet}}">
+      query-matches="{{tablet}}">
     </iron-media-query>
 
     <expense-editor></expense-editor>
@@ -78,24 +78,11 @@
     (function() {
       /**
        * @memberof ExpenseManager
+       * @mixes ExpenseManager.ResponsiveMixin
        */
-      class OverviewPageElement extends ExpenseManager.ReduxMixin(Polymer.GestureEventListeners(Polymer.Element)) {
+      class OverviewPageElement extends ExpenseManager.ReduxMixin(ExpenseManager.ResponsiveMixin(Polymer.Element)) {
         static get is() {
           return 'overview-page';
-        }
-
-        static get properties() {
-          return {
-            /**
-             * Whether the screen matches the phone breakpoint.
-             */
-            _phone: Boolean,
-
-            /**
-             * Whether the screen matches the tablet breakpoint.
-             */
-            _tablet: Boolean
-          };
         }
       }
 

--- a/src/responsive-mixin.html
+++ b/src/responsive-mixin.html
@@ -1,0 +1,31 @@
+<script>
+  window.ExpenseManager = window.ExpenseManager || {};
+
+  /**
+   * @polymerMixin
+   * @memberof ExpenseManager
+   * @param {HTMLElement} subclass
+   * @return {HTMLElement}
+   */
+  ExpenseManager.ResponsiveMixin = subclass => class ResponsiveMixin extends subclass {
+    static get properties() {
+      return {
+        /**
+         * Whether the screen matches the tablet breakpoint.
+         */
+        tablet: {
+          type: Boolean,
+          reflectToAttribute: true
+        },
+
+        /**
+         * Whether the screen matches the phone breakpoint.
+         */
+        phone: {
+          type: Boolean,
+          reflectToAttribute: true
+        }
+      };
+    }
+  };
+</script>

--- a/src/search-filters.html
+++ b/src/search-filters.html
@@ -10,6 +10,7 @@
 <link rel="import" href="data/store.html">
 <link rel="import" href="data/constants.html">
 
+<link rel="import" href="responsive-mixin.html">
 <link rel="import" href="shared-styles.html">
 
 <dom-module id="search-filters">
@@ -95,8 +96,9 @@
     (function() {
       /**
        * @memberof ExpenseManager
+       * @mixes ExpenseManager.ResponsiveMixin
        */
-      class SearchFiltersElement extends ExpenseManager.ReduxMixin(Polymer.Element) {
+      class SearchFiltersElement extends ExpenseManager.ReduxMixin(ExpenseManager.ResponsiveMixin(Polymer.Element)) {
         static get is() {
           return 'search-filters';
         }
@@ -133,22 +135,6 @@
             statusOptions: {
               type: Array,
               value: () => ExpenseManager.constants.statuses
-            },
-
-            /**
-             * Whether the screen matches the phone breakpoint.
-             */
-            phone: {
-              type: Boolean,
-              reflectToAttribute: true
-            },
-
-            /**
-             * Whether the screen matches the tablet breakpoint.
-             */
-            tablet: {
-              type: Boolean,
-              reflectToAttribute: true
             }
           };
         }


### PR DESCRIPTION
Connected to #62 

The goal here is to reduce bundle size and demonstrate how to use and annotate mixins. Also removed a few `GestureEventListeners ` usages to keep formatting nice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/expense-manager-demo/77)
<!-- Reviewable:end -->
