### PR TITLE
Replace paper-icon-button and cleanup styles

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-vaadin"
+}

--- a/bower.json
+++ b/bower.json
@@ -21,12 +21,12 @@
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.0.0",
     "app-layout": "polymerelements/app-layout#^2.0.0",
     "iron-a11y-keys": "polymerelements/iron-a11y-keys#^2.0.0",
-    "iron-icons": "polymerelements/iron-icons#^2.0.0",
+    "iron-icon": "polymerelements/iron-icon#^2.0.0",
+    "iron-iconset-svg": "polymerelements/iron-iconset-svg#^2.0.0",
     "iron-pages": "polymerelements/iron-pages#^2.0.0",
     "iron-media-query": "polymerelements/iron-media-query#^2.0.0",
     "paper-fab": "polymerelements/paper-fab#^2.0.0",
-    "polymer-redux": "^1.0.3",
-    "paper-icon-button": "PolymerElements/paper-icon-button#^2.0.1"
+    "polymer-redux": "^1.0.3"
   },
   "devDependencies": {
     "web-component-tester": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -158,6 +158,18 @@
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
       "dev": true
     },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-iterate": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.1.tgz",
+      "integrity": "sha1-hlv3+K851rCYLGCQKRSsdrwBCPY=",
+      "dev": true
+    },
     "array-slice": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
@@ -203,6 +215,20 @@
       "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
       "dev": true
     },
+    "autoprefixer": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
+      "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
+      "dev": true,
+      "requires": {
+        "browserslist": "2.11.3",
+        "caniuse-lite": "1.0.30000809",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "6.0.19",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -237,6 +263,12 @@
           }
         }
       }
+    },
+    "bail": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
+      "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q=",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -294,6 +326,22 @@
         "to-regex": "3.0.1"
       }
     },
+    "browserslist": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "1.0.30000809",
+        "electron-to-chromium": "1.3.33"
+      }
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -326,6 +374,35 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+      "dev": true,
+      "requires": {
+        "camelcase": "4.1.0",
+        "map-obj": "2.0.0",
+        "quick-lru": "1.1.0"
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000809.tgz",
+      "integrity": "sha512-tLn4flj2upmMsko3larTkQh21Vp9pylnNPUOhw5+mubL+67U5Fpm4UG5AutzGBc+gBIPSsPFHDynsiMWp5m46g==",
+      "dev": true
+    },
+    "ccount": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
+      "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok=",
+      "dev": true
+    },
     "chalk": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
@@ -356,6 +433,30 @@
           }
         }
       }
+    },
+    "character-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
+      "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco=",
+      "dev": true
+    },
+    "character-entities-html4": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.1.tgz",
+      "integrity": "sha1-NZoqSg9+KdPcKsmb2+Ie45Q46lA=",
+      "dev": true
+    },
+    "character-entities-legacy": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
+      "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8=",
+      "dev": true
+    },
+    "character-reference-invalid": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
+      "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw=",
+      "dev": true
     },
     "chardet": {
       "version": "0.4.2",
@@ -470,6 +571,16 @@
       "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
       "dev": true
     },
+    "clone-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.0.tgz",
+      "integrity": "sha1-6uCiQT9VwJQvgYwin+/OhF1/Oxw=",
+      "dev": true,
+      "requires": {
+        "is-regexp": "1.0.0",
+        "is-supported-regexp-flag": "1.0.0"
+      }
+    },
     "clone-stats": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
@@ -480,6 +591,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "collapse-white-space": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
+      "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw=",
       "dev": true
     },
     "collection-visit": {
@@ -571,6 +688,18 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cosmiconfig": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -580,6 +709,15 @@
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
       }
     },
     "dateformat": {
@@ -595,6 +733,30 @@
       "dev": true,
       "requires": {
         "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "1.2.0",
+        "map-obj": "1.0.1"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
       }
     },
     "decode-uri-component": {
@@ -661,6 +823,16 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
+    "dir-glob": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
+      }
+    },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -726,6 +898,15 @@
         "domelementtype": "1.3.0"
       }
     },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "1.0.1"
+      }
+    },
     "duplexer2": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
@@ -784,6 +965,12 @@
         }
       }
     },
+    "electron-to-chromium": {
+      "version": "1.3.33",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
+      "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU=",
+      "dev": true
+    },
     "end-of-stream": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
@@ -809,6 +996,15 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
       "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
     },
     "es6-promise": {
       "version": "2.3.0",
@@ -944,6 +1140,15 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "execall": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
+      "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+      "dev": true,
+      "requires": {
+        "clone-regexp": "1.0.0"
+      }
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -1211,6 +1416,15 @@
       "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
       "dev": true
     },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "requires": {
+        "locate-path": "2.0.0"
+      }
+    },
     "findup-sync": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
@@ -1304,6 +1518,12 @@
       "requires": {
         "globule": "0.1.0"
       }
+    },
+    "get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+      "dev": true
     },
     "get-value": {
       "version": "2.0.6",
@@ -1513,6 +1733,12 @@
         "pinkie-promise": "2.0.1"
       }
     },
+    "globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
+      "dev": true
+    },
     "globule": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
@@ -1578,6 +1804,23 @@
       "dev": true,
       "requires": {
         "sparkles": "1.0.0"
+      }
+    },
+    "gonzales-pe": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.3.tgz",
+      "integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
+      "dev": true,
+      "requires": {
+        "minimist": "1.1.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
+          "dev": true
+        }
       }
     },
     "got": {
@@ -2077,6 +2320,18 @@
         "parse-passwd": "1.0.0"
       }
     },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
+    },
+    "html-tags": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
+      "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
+      "dev": true
+    },
     "htmlparser2": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
@@ -2172,6 +2427,18 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "dev": true
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
     "infinity-agent": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
@@ -2248,11 +2515,48 @@
         "kind-of": "6.0.2"
       }
     },
+    "is-alphabetical": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
+      "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg=",
+      "dev": true
+    },
+    "is-alphanumeric": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+      "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
+      "dev": true
+    },
+    "is-alphanumerical": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
+      "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
+      "dev": true,
+      "requires": {
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-data-descriptor": {
       "version": "1.0.0",
@@ -2262,6 +2566,12 @@
       "requires": {
         "kind-of": "6.0.2"
       }
+    },
+    "is-decimal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
+      "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "1.0.2",
@@ -2273,6 +2583,12 @@
         "is-data-descriptor": "1.0.0",
         "kind-of": "6.0.2"
       }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -2326,6 +2642,12 @@
         "is-extglob": "2.1.1"
       }
     },
+    "is-hexadecimal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
+      "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk=",
+      "dev": true
+    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -2352,6 +2674,12 @@
           }
         }
       }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
     },
     "is-odd": {
       "version": "1.0.0",
@@ -2385,6 +2713,12 @@
       "requires": {
         "path-is-inside": "1.0.2"
       }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -2420,6 +2754,12 @@
       "dev": true,
       "optional": true
     },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
     "is-relative": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
@@ -2439,6 +2779,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-supported-regexp-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz",
+      "integrity": "sha1-i1IMhfrnolM4LUsCZS4EVXbhO7g=",
       "dev": true
     },
     "is-unc-path": {
@@ -2462,10 +2808,22 @@
       "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
       "dev": true
     },
+    "is-whitespace-character": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz",
+      "integrity": "sha1-muAXbzKCtlRXoZks2whPil+DPjs=",
+      "dev": true
+    },
     "is-windows": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
       "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
+      "dev": true
+    },
+    "is-word-character": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.1.tgz",
+      "integrity": "sha1-WgP6HqkazopusMfNdw64bWXIvvs=",
       "dev": true
     },
     "isarray": {
@@ -2486,6 +2844,12 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "js-base64": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
+      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -2500,6 +2864,12 @@
         "argparse": "1.0.9",
         "esprima": "4.0.0"
       }
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
@@ -2532,6 +2902,12 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
+    },
+    "known-css-properties": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.5.0.tgz",
+      "integrity": "sha512-LOS0CoS8zcZnB1EjLw4LLqDXw8nvt3AGH5dXLQP3D9O1nLLA+9GC5GnPl5mmF+JiQAtSX4VyZC7KvEtcA4kUtA==",
       "dev": true
     },
     "latest-version": {
@@ -2586,6 +2962,52 @@
         "object.map": "1.0.1",
         "rechoir": "0.6.2",
         "resolve": "1.5.0"
+      }
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
+        "strip-bom": "3.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -2723,12 +3145,37 @@
         "lodash.escape": "3.2.0"
       }
     },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.1"
+      }
+    },
+    "longest-streak": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
+      "integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA==",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
         "js-tokens": "3.0.2"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lowercase-keys": {
@@ -2774,6 +3221,12 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
+    "map-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+      "dev": true
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -2781,6 +3234,59 @@
       "dev": true,
       "requires": {
         "object-visit": "1.0.1"
+      }
+    },
+    "markdown-escapes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.1.tgz",
+      "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg=",
+      "dev": true
+    },
+    "markdown-table": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.1.tgz",
+      "integrity": "sha1-Sz3ToTPRUYuO8NvHCb8qG0gkvIw=",
+      "dev": true
+    },
+    "mathml-tag-names": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.0.1.tgz",
+      "integrity": "sha1-jUEmgWi/htEQK5gQnijlMeejRXg=",
+      "dev": true
+    },
+    "mdast-util-compact": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz",
+      "integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
+      "dev": true,
+      "requires": {
+        "unist-util-modify-children": "1.1.1",
+        "unist-util-visit": "1.3.0"
+      }
+    },
+    "meow": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
+      "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "4.2.0",
+        "decamelize-keys": "1.1.0",
+        "loud-rejection": "1.6.0",
+        "minimist": "1.2.0",
+        "minimist-options": "3.0.2",
+        "normalize-package-data": "2.4.0",
+        "read-pkg-up": "3.0.0",
+        "redent": "2.0.0",
+        "trim-newlines": "2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "merge-stream": {
@@ -2833,6 +3339,16 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "is-plain-obj": "1.1.0"
+      }
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -2943,6 +3459,18 @@
         "abbrev": "1.1.1"
       }
     },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.1"
+      }
+    },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -2951,6 +3479,24 @@
       "requires": {
         "remove-trailing-separator": "1.1.0"
       }
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
+    "normalize-selector": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+      "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
+      "dev": true
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -3166,6 +3712,30 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "p-limit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.2.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
     "package-json": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
@@ -3175,6 +3745,20 @@
       "requires": {
         "got": "3.3.1",
         "registry-url": "3.1.0"
+      }
+    },
+    "parse-entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz",
+      "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
+      "dev": true,
+      "requires": {
+        "character-entities": "1.2.1",
+        "character-entities-legacy": "1.1.1",
+        "character-reference-invalid": "1.1.1",
+        "is-alphanumerical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-hexadecimal": "1.0.1"
       }
     },
     "parse-filepath": {
@@ -3217,6 +3801,15 @@
         }
       }
     },
+    "parse-json": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+      "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -3239,6 +3832,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
@@ -3280,6 +3879,23 @@
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
     },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -3311,6 +3927,182 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "postcss": {
+      "version": "6.0.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+      "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.1",
+        "source-map": "0.6.1",
+        "supports-color": "5.2.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-html": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.12.0.tgz",
+      "integrity": "sha512-KxKUpj7AY7nlCbLcTOYxdfJnGE7QFAfU2n95ADj1Q90RM/pOLdz8k3n4avOyRFs7MDQHcRzJQWM1dehCwJxisQ==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "3.9.2",
+        "remark": "8.0.0",
+        "unist-util-find-all-after": "1.0.1"
+      }
+    },
+    "postcss-less": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.3.tgz",
+      "integrity": "sha512-WS0wsQxRm+kmN8wEYAGZ3t4lnoNfoyx9EJZrhiPR1K0lMHR0UNWnz52Ya5QRXChHtY75Ef+kDc05FpnBujebgw==",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "5.2.18",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "postcss-media-query-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
+      "dev": true
+    },
+    "postcss-reporter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-5.0.0.tgz",
+      "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.1",
+        "lodash": "4.17.5",
+        "log-symbols": "2.2.0",
+        "postcss": "6.0.19"
+      }
+    },
+    "postcss-resolve-nested-selector": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
+      "dev": true
+    },
+    "postcss-safe-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-3.0.1.tgz",
+      "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
+      "dev": true,
+      "requires": {
+        "postcss": "6.0.19"
+      }
+    },
+    "postcss-sass": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.2.0.tgz",
+      "integrity": "sha512-cUmYzkP747fPCQE6d+CH2l1L4VSyIlAzZsok3HPjb5Gzsq3jE+VjpAdGlPsnQ310WKWI42sw+ar0UNN59/f3hg==",
+      "dev": true,
+      "requires": {
+        "gonzales-pe": "4.2.3",
+        "postcss": "6.0.19"
+      }
+    },
+    "postcss-scss": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.3.tgz",
+      "integrity": "sha512-N2ZPDOV5PGEGVwdiB7b1QppxKkmkHodNWkemja7PV+/mHqbUlA6ZcYRreden5Ag5nwBBX8/aRE7lfg1xjdszyg==",
+      "dev": true,
+      "requires": {
+        "postcss": "6.0.19"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+      "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+      "dev": true,
+      "requires": {
+        "dot-prop": "4.2.0",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
       "dev": true
     },
     "prelude-ls": {
@@ -3354,6 +4146,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
     "randomatic": {
@@ -3410,6 +4208,27 @@
         "readable-stream": "2.3.4"
       }
     },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "4.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "3.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "3.0.0"
+      }
+    },
     "readable-stream": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
@@ -3432,6 +4251,16 @@
       "dev": true,
       "requires": {
         "resolve": "1.5.0"
+      }
+    },
+    "redent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+      "dev": true,
+      "requires": {
+        "indent-string": "3.2.0",
+        "strip-indent": "2.0.0"
       }
     },
     "redux": {
@@ -3478,6 +4307,62 @@
         "rc": "1.2.5"
       }
     },
+    "remark": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-8.0.0.tgz",
+      "integrity": "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==",
+      "dev": true,
+      "requires": {
+        "remark-parse": "4.0.0",
+        "remark-stringify": "4.0.0",
+        "unified": "6.1.6"
+      }
+    },
+    "remark-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-4.0.0.tgz",
+      "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
+      "dev": true,
+      "requires": {
+        "collapse-white-space": "1.0.3",
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-whitespace-character": "1.0.1",
+        "is-word-character": "1.0.1",
+        "markdown-escapes": "1.0.1",
+        "parse-entities": "1.1.1",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "1.1.0",
+        "unherit": "1.1.0",
+        "unist-util-remove-position": "1.1.1",
+        "vfile-location": "2.0.2",
+        "xtend": "4.0.1"
+      }
+    },
+    "remark-stringify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-4.0.0.tgz",
+      "integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
+      "dev": true,
+      "requires": {
+        "ccount": "1.0.2",
+        "is-alphanumeric": "1.0.0",
+        "is-decimal": "1.0.1",
+        "is-whitespace-character": "1.0.1",
+        "longest-streak": "2.0.2",
+        "markdown-escapes": "1.0.1",
+        "markdown-table": "1.1.1",
+        "mdast-util-compact": "1.0.1",
+        "parse-entities": "1.1.1",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.0",
+        "stringify-entities": "1.3.1",
+        "unherit": "1.1.0",
+        "xtend": "4.0.1"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -3510,6 +4395,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
       "dev": true
     },
     "require-uncached": {
@@ -3675,6 +4566,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
     "slice-ansi": {
@@ -3848,6 +4745,33 @@
       "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
       "dev": true
     },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
+    },
+    "specificity": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.3.2.tgz",
+      "integrity": "sha512-Nc/QN/A425Qog7j9aHmwOrlwX2e7pNI47ciwxwy4jOlvbbMHkNNJchit+FX+UjF3IAdiaaV5BKeWuDUnws6G1A==",
+      "dev": true
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -3882,6 +4806,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "state-toggle": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.0.tgz",
+      "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU=",
       "dev": true
     },
     "static-extend": {
@@ -4015,6 +4945,18 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "stringify-entities": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.1.tgz",
+      "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
+      "dev": true,
+      "requires": {
+        "character-entities-html4": "1.1.1",
+        "character-entities-legacy": "1.1.1",
+        "is-alphanumerical": "1.0.1",
+        "is-hexadecimal": "1.0.1"
+      }
+    },
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -4063,16 +5005,213 @@
         }
       }
     },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "style-search": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
+      "dev": true
+    },
+    "stylelint": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-8.4.0.tgz",
+      "integrity": "sha512-56hPH5mTFnk8LzlEuTWq0epa34fHuS54UFYQidBOFt563RJBNi1nz1F2HK2MoT1X1waq47milvRsRahFCCJs/Q==",
+      "dev": true,
+      "requires": {
+        "autoprefixer": "7.2.6",
+        "balanced-match": "1.0.0",
+        "chalk": "2.3.1",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "execall": "1.0.0",
+        "file-entry-cache": "2.0.0",
+        "get-stdin": "5.0.1",
+        "globby": "7.1.1",
+        "globjoin": "0.1.4",
+        "html-tags": "2.0.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "known-css-properties": "0.5.0",
+        "lodash": "4.17.5",
+        "log-symbols": "2.2.0",
+        "mathml-tag-names": "2.0.1",
+        "meow": "4.0.0",
+        "micromatch": "2.3.11",
+        "normalize-selector": "0.2.0",
+        "pify": "3.0.0",
+        "postcss": "6.0.19",
+        "postcss-html": "0.12.0",
+        "postcss-less": "1.1.3",
+        "postcss-media-query-parser": "0.2.3",
+        "postcss-reporter": "5.0.0",
+        "postcss-resolve-nested-selector": "0.1.1",
+        "postcss-safe-parser": "3.0.1",
+        "postcss-sass": "0.2.0",
+        "postcss-scss": "1.0.3",
+        "postcss-selector-parser": "3.1.1",
+        "postcss-value-parser": "3.3.0",
+        "resolve-from": "4.0.0",
+        "specificity": "0.3.2",
+        "string-width": "2.1.1",
+        "style-search": "0.1.0",
+        "sugarss": "1.0.1",
+        "svg-tags": "1.0.0",
+        "table": "4.0.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "globby": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "dir-glob": "2.0.0",
+            "glob": "7.1.2",
+            "ignore": "3.3.7",
+            "pify": "3.0.0",
+            "slash": "1.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
+    },
+    "stylelint-config-vaadin": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/stylelint-config-vaadin/-/stylelint-config-vaadin-0.1.2.tgz",
+      "integrity": "sha512-geoLHnAxF0BnAwU8OfWmQCCUCfc4NhPQtCiuibEhdD6KH+CkY0iDgAAifEhNu0J6fiJ0S4H0SbL9/AbCqwsWkg==",
+      "dev": true
+    },
+    "sugarss": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz",
+      "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
+      "dev": true,
+      "requires": {
+        "postcss": "6.0.19"
+      }
+    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
     },
     "symbol-observable": {
@@ -4275,6 +5414,30 @@
         "repeat-string": "1.6.1"
       }
     },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
+    "trim-newlines": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+      "dev": true
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
+      "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ=",
+      "dev": true
+    },
+    "trough": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.1.tgz",
+      "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y=",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -4302,6 +5465,31 @@
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
     },
+    "unherit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
+      "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "unified": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-6.1.6.tgz",
+      "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
+      "dev": true,
+      "requires": {
+        "bail": "1.0.2",
+        "extend": "3.0.1",
+        "is-plain-obj": "1.1.0",
+        "trough": "1.0.1",
+        "vfile": "2.3.0",
+        "x-is-function": "1.0.4",
+        "x-is-string": "0.1.0"
+      }
+    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -4328,11 +5516,65 @@
         }
       }
     },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
     "unique-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
       "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
       "dev": true
+    },
+    "unist-util-find-all-after": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.1.tgz",
+      "integrity": "sha1-TlUSq/734GFnga7Pex7XUcAK+Qg=",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "2.1.1"
+      }
+    },
+    "unist-util-is": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.1.tgz",
+      "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs=",
+      "dev": true
+    },
+    "unist-util-modify-children": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.1.tgz",
+      "integrity": "sha1-ZtfmpEnm9nIguXarPLi166w55R0=",
+      "dev": true,
+      "requires": {
+        "array-iterate": "1.1.1"
+      }
+    },
+    "unist-util-remove-position": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz",
+      "integrity": "sha1-WoXBVV/BugwQG4ZwfRXlD6TIcbs=",
+      "dev": true,
+      "requires": {
+        "unist-util-visit": "1.3.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz",
+      "integrity": "sha1-PMvcU2ee7W7PN3fdf14yKcG2qjw=",
+      "dev": true
+    },
+    "unist-util-visit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.0.tgz",
+      "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "2.1.1"
+      }
     },
     "unset-value": {
       "version": "1.0.0",
@@ -4535,6 +5777,51 @@
       "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
       "dev": true
     },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "vfile": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+      "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.6",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "1.1.1",
+        "vfile-message": "1.0.0"
+      },
+      "dependencies": {
+        "replace-ext": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+          "dev": true
+        }
+      }
+    },
+    "vfile-location": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.2.tgz",
+      "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU=",
+      "dev": true
+    },
+    "vfile-message": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.0.tgz",
+      "integrity": "sha512-HPREhzTOB/sNDc9/Mxf8w0FmHnThg5CRSJdR9VRFkD2riqYWs+fuXlj5z8mIpv2LrD7uU41+oPWFOL4Mjlf+dw==",
+      "dev": true,
+      "requires": {
+        "unist-util-stringify-position": "1.1.1"
+      }
+    },
     "vinyl": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -4686,6 +5973,18 @@
         "imurmurhash": "0.1.4",
         "slide": "1.1.6"
       }
+    },
+    "x-is-function": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/x-is-function/-/x-is-function-1.0.4.tgz",
+      "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4=",
+      "dev": true
+    },
+    "x-is-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+      "dev": true
     },
     "xdg-basedir": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
     "http2-push-manifest": "^1.0.0",
     "eslint": "^4.0.0",
     "eslint-config-vaadin": "latest",
-    "eslint-plugin-html": "^4.0.0"
+    "eslint-plugin-html": "^4.0.0",
+    "stylelint": "^8.0.0",
+    "stylelint-config-vaadin": "latest"
   },
   "scripts": {
-    "lint": "npm run lint:javascript",
+    "lint": "npm run lint:javascript & npm run lint:css",
+    "lint:css": "stylelint src/*.html",
     "lint:javascript": "eslint . --ext html --ignore-path .gitignore",
     "test": "polymer test",
     "test:integration": "polymer build # test that psk builds without error with the CLI"

--- a/src/expense-app.html
+++ b/src/expense-app.html
@@ -16,70 +16,18 @@
       }
 
       #pages,
-      #pages>* {
+      #pages > * {
         position: absolute;
         top: 0;
         right: 0;
         bottom: 0;
         left: 0;
       }
-
-      :host>* {
-        --dark-primary-color: var(--lumo-base-color);
-        --primary-color: var(--lumo-primary-color);
-        --light-primary-color: #F2FAF9;
-        --text-primary-color: #FFFFFF;
-        --accent-color: var(--lumo-error-color);
-        --light-accent-color: #F2FAF9;
-        --primary-text-color: rgba(0, 0, 0, 0.87);
-        --secondary-text-color: #727272;
-        --primary-background-color: #FFFFFF;
-        --disabled-text-color: #BDBDBD;
-        --divider-color: #B6B6B6;
-        --paper-menu-background-color: #fff;
-        --menu-link-color: #111111;
-        --paper-input-container-underline: {
-          background: #dbdbdb;
-        }
-        --paper-header-panel-shadow: {
-          display: none;
-        }
-        --paper-header-panel-standard-container: {
-          overflow: visible;
-        }
-        --vaadin-upload-button-add: {
-          background: transparent;
-          color: var(--primary-color);
-          box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
-        }
-        --vaadin-upload-buttons-primary: {
-          flex-direction: column;
-          align-items: center;
-        }
-        --section-title: {
-          font-weight: 400;
-          font-size: 13px;
-          display: block;
-          border-bottom: 1px solid rgba(0, 0, 0, 0.13);
-          padding-bottom: 6px;
-          margin-bottom: 18px;
-          margin-top: 4px;
-          color: rgba(0, 0, 0, 0.54);
-        }
-        iron-overlay-backdrop {
-          --iron-overlay-backdrop-background-color: #33383A;
-        }
-
-        --paper-input-container-underline: {
-          border-color: rgba(0, 0, 0, 0.2);
-        }
-      }
-
     </style>
 
     <iron-pages id="pages" selected="[[activePage]]" selected-attribute="active">
-      <login-page id="login" theme="dark"></login-page>
-      <overview-page id="overview"></overview-page>
+      <login-page theme="dark"></login-page>
+      <overview-page></overview-page>
     </iron-pages>
   </template>
 

--- a/src/expense-editor.html
+++ b/src/expense-editor.html
@@ -17,14 +17,23 @@
     <vaadin-dialog id="dialog" no-close-on-esc no-close-on-outside-click opened="[[_isDialogOpened(_expense)]]">
       <template>
         <style>
-          .main-layout {
+          [part~="content"] {
+            padding: var(--lumo-space-l);
+          }
+
+          .header {
             display: flex;
             justify-content: space-between;
-            align-items: center;
+            align-items: flex-start;
+          }
+
+          .close-button {
+            margin: 0;
           }
 
           .wrapper {
             display: flex;
+            margin-top: var(--lumo-space-s);
           }
 
           #form {
@@ -34,7 +43,11 @@
           }
 
           #upload {
-            margin-left: 30px;
+            margin-left: var(--lumo-space-l);
+          }
+
+          .buttons vaadin-button {
+            margin-right: var(--lumo-space-m);
           }
 
           @media (max-width: 900px) {
@@ -57,9 +70,9 @@
           }
         </style>
 
-        <div class="main-layout">
+        <div class="header">
           <h2>[[_getCaption(_expense)]]</h2>
-          <vaadin-button on-click="close" theme="icon">
+          <vaadin-button on-click="close" theme="icon" class="close-button">
             <iron-icon icon="expense-manager:close"></iron-icon>
           </vaadin-button>
         </div>
@@ -84,10 +97,10 @@
           </vaadin-upload>
         </div>
 
-        <div class="buttons-layout">
+        <div class="buttons">
           <vaadin-button on-click="_save" theme="primary" class="save-button">Save</vaadin-button>
           <vaadin-button on-click="close" class="cancel-button">Cancel</vaadin-button>
-          <vaadin-button on-click="_delete" id="delete" theme="tertiary danger" class="delete-button" hidden="[[!_showDelete(_expense)]]">Delete</vaadin-button>
+          <vaadin-button on-click="_delete" id="delete" theme="tertiary error" class="delete-button" hidden="[[!_showDelete(_expense)]]">Delete</vaadin-button>
         </div>
         <span>[[_errorText]]</span>
       </template>

--- a/src/expense-editor.html
+++ b/src/expense-editor.html
@@ -1,17 +1,16 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/polymer/lib/mixins/gesture-event-listeners.html">
-<link rel="import" href="../bower_components/vaadin-dialog/vaadin-dialog.html">
-<link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
-
-<link rel="import" href="../bower_components/vaadin-text-field/vaadin-text-field.html">
+<link rel="import" href="../bower_components/iron-a11y-keys/iron-a11y-keys.html">
+<link rel="import" href="../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../bower_components/vaadin-button/vaadin-button.html">
-<link rel="import" href="../bower_components/vaadin-date-picker/vaadin-date-picker.html">
 <link rel="import" href="../bower_components/vaadin-combo-box/vaadin-combo-box.html">
+<link rel="import" href="../bower_components/vaadin-date-picker/vaadin-date-picker.html">
+<link rel="import" href="../bower_components/vaadin-dialog/vaadin-dialog.html">
+<link rel="import" href="../bower_components/vaadin-text-field/vaadin-text-field.html">
 <link rel="import" href="../bower_components/vaadin-upload/vaadin-upload.html">
 
-<link rel="import" href="../bower_components/iron-a11y-keys/iron-a11y-keys.html">
-
 <link rel="import" href="data/store.html">
+<link rel="import" href="icons.html">
 
 <dom-module id="expense-editor">
   <template>
@@ -20,10 +19,8 @@
         <style>
           .main-layout {
             display: flex;
-          }
-
-          .main-layout h2 {
-            flex: 1;
+            justify-content: space-between;
+            align-items: center;
           }
 
           .wrapper {
@@ -62,7 +59,9 @@
 
         <div class="main-layout">
           <h2>[[_getCaption(_expense)]]</h2>
-          <paper-icon-button icon="close" on-click="close" class="close-button self-start"></paper-icon-button>
+          <vaadin-button on-click="close" theme="icon">
+            <iron-icon icon="expense-manager:close"></iron-icon>
+          </vaadin-button>
         </div>
 
         <div class="wrapper">

--- a/src/expenses-list.html
+++ b/src/expenses-list.html
@@ -3,22 +3,9 @@
 <link rel="import" href="../bower_components/vaadin-grid/vaadin-grid.html">
 <link rel="import" href="../bower_components/vaadin-grid/vaadin-grid-sorter.html">
 <link rel="import" href="../bower_components/paper-fab/paper-fab.html">
-<link rel="import" href="../bower_components/iron-icons/iron-icons.html">
 <link rel="import" href="moment-js.html">
 <link rel="import" href="data/store.html">
-
-
-
-<!-- Guard against vaadin-license-dialog styles. For some reason the #header styles are not scoped
-if the license checker is collapsed to the top right corner on page load, and the scoping is fixed
-if you open the license dialog. -->
-<style>
-  vaadin-grid thead#header {
-    padding: 0;
-    margin: 0;
-  }
-
-</style>
+<link rel="import" href="icons.html">
 
 <dom-module id="expenses-list">
   <template>
@@ -50,7 +37,7 @@ if you open the license dialog. -->
       }
 
       vaadin-grid .status-new {
-        color: var(--accent-color);
+        color: var(--lumo-error-color);
         font-weight: 500;
       }
 
@@ -146,7 +133,7 @@ if you open the license dialog. -->
       </vaadin-grid-column>
 
     </vaadin-grid>
-    <paper-fab icon="add" on-tap="_showExpenseEditor" id="add-button"></paper-fab>
+    <paper-fab icon="expense-manager:add" on-tap="_showExpenseEditor" id="add-button"></paper-fab>
   </template>
   <script>
     (function() {

--- a/src/filters-toolbar.html
+++ b/src/filters-toolbar.html
@@ -3,6 +3,8 @@
 <link rel="import" href="../bower_components/polymer/lib/mixins/gesture-event-listeners.html">
 <link rel="import" href="../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
+<link rel="import" href="../bower_components/vaadin-lumo-styles/sizing.html">
+<link rel="import" href="../bower_components/vaadin-lumo-styles/spacing.html">
 <link rel="import" href="../bower_components/vaadin-button/vaadin-button.html">
 <link rel="import" href="search-filters.html">
 <link rel="import" href="data/store.html">
@@ -26,30 +28,21 @@
         flex-direction: column;
       }
 
-      #toolbar {
+      .toolbar {
         display: flex;
         flex-shrink: 0;
-        padding: 0 16px;
-        height: 48px;
+        padding: 0 var(--lumo-space-m);
+        height: var(--lumo-size-xl);
+        justify-content: space-between;
         align-items: center;
+      }
+
+      .toolbar[hidden] {
+        display: none;
       }
 
       #filters {
         transition: max-height 400ms cubic-bezier(0.4, 0, 0.2, 1);
-      }
-
-      #toolbar[hidden] {
-        display: none;
-      }
-
-      #total {
-        z-index: 2;
-        pointer-events: none;
-      }
-
-      #total .sum {
-        font-size: 32px;
-        font-weight: 300;
       }
 
       .count {
@@ -76,10 +69,7 @@
       }
 
       .total {
-        display: flex;
-        flex-direction: column;
-        flex: 1;
-        line-height: initial;
+        line-height: var(--lumo-line-height-xs);
       }
 
       .total .sum {
@@ -87,10 +77,10 @@
       }
     </style>
 
-    <div id="toolbar" hidden="[[!phone]]">
+    <div class="toolbar" hidden="[[!phone]]">
       <div class="total">
         <small>To be reimbursed</small>
-        <span class="sum">$[[totalOwed]]</span>
+        <div class="sum">$[[totalOwed]]</div>
       </div>
       <vaadin-button theme="tertiary" on-click="_toggleFilters">
         <iron-icon icon="expense-manager:filters" slot="suffix"></iron-icon>

--- a/src/filters-toolbar.html
+++ b/src/filters-toolbar.html
@@ -1,10 +1,12 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/polymer/lib/mixins/gesture-event-listeners.html">
 <link rel="import" href="../bower_components/polymer/lib/mixins/gesture-event-listeners.html">
+<link rel="import" href="../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
 <link rel="import" href="../bower_components/vaadin-button/vaadin-button.html">
 <link rel="import" href="search-filters.html">
 <link rel="import" href="data/store.html">
+<link rel="import" href="icons.html">
 
 <dom-module id="filters-toolbar">
   <template>
@@ -25,7 +27,7 @@
       }
 
       #toolbar {
-        display: none;
+        display: flex;
         flex-shrink: 0;
         padding: 0 16px;
         height: 48px;
@@ -33,11 +35,11 @@
       }
 
       #filters {
-        transition: max-height 400ms cubic-bezier(0.4, 0.0, 0.2, 1);
+        transition: max-height 400ms cubic-bezier(0.4, 0, 0.2, 1);
       }
 
-      #toolbar:not([hidden]) {
-        display: flex;
+      #toolbar[hidden] {
+        display: none;
       }
 
       #total {
@@ -50,49 +52,27 @@
         font-weight: 300;
       }
 
-      #filters-toggle {
-        position: relative;
-        color: var(--primary-color);
-      }
-
-      #filters-toggle .count {
+      .count {
         position: absolute;
-        top: 6px;
-        right: 0px;
+        top: 4px;
+        right: -4px;
         z-index: 1;
         width: 16px;
         height: 16px;
-        line-height: 16px;
         overflow: hidden;
         text-align: center;
         border-radius: 50%;
-        background: var(--accent-color);
-        color: var(--text-primary-color);
-        font-size: 12px;
+        color: var(--lumo-error-contrast-color);
+        background-color: var(--lumo-error-color);
+        font-family: var(--lumo-font-family);
+        font-size: var(--lumo-font-size-xs);
+        line-height: var(--lumo-line-height-xs);
         transform: scale(0);
-        transition: all 400ms cubic-bezier(0.4, 0.0, 0.2, 1);
+        transition: all 400ms cubic-bezier(0.4, 0, 0.2, 1);
       }
 
-      #filters-toggle .count[has-filters] {
+      .count[has-filters] {
         transform: scale(1);
-      }
-
-      #filters-caption {
-        display: none;
-      }
-
-      #buttons {
-        justify-content: space-between;
-      }
-
-      #done-button {
-        background: var(--primary-color);
-        color: var(--text-primary-color);
-        text-align: center;
-      }
-
-      .clear-button {
-        color: var(--primary-color);
       }
 
       .total {
@@ -105,18 +85,18 @@
       .total .sum {
         font-weight: 300;
       }
-
     </style>
+
     <div id="toolbar" hidden="[[!phone]]">
       <div class="total">
         <small>To be reimbursed</small>
         <span class="sum">$[[totalOwed]]</span>
       </div>
-      <div id="filters-toggle" on-tap="_toggleFilters">
+      <vaadin-button theme="tertiary" on-click="_toggleFilters">
+        <iron-icon icon="expense-manager:filters" slot="suffix"></iron-icon>
         <span>Filters</span>
-        <div class="count" has-filters$="[[_hasFilters(appliedFilters)]]">[[appliedFilters]]</div>
-        <paper-icon-button icon="filter-list"></paper-icon-button>
-      </div>
+        <div class="count" slot="suffix" has-filters$="[[_hasFilters(appliedFilters)]]">[[appliedFilters]]</div>
+      </vaadin-button>
     </div>
 
     <search-filters phone="[[phone]]" tablet="[[tablet]]" id="filters"></search-filters>

--- a/src/history-panel.html
+++ b/src/history-panel.html
@@ -32,10 +32,6 @@
         flex-direction: column;
       }
 
-      .chart-title {
-        @apply --section-title;
-      }
-
       #horizontal {
         display: none;
       }
@@ -64,24 +60,16 @@
         display: block;
       }
 
-      @media (max-width: 900px) {
-        .total {
-          height: 64px;
-          flex-direction: row;
-        }
-        .total .sum {
-          margin-left: 12px;
-        }
-      }
-
       @media (max-width: 1124px) {
         #horizontal {
           display: flex;
         }
+
         #total {
           flex: 1;
           margin-left: 16px;
         }
+
         #total .sum {
           display: block;
           text-align: center;

--- a/src/history-panel.html
+++ b/src/history-panel.html
@@ -14,9 +14,10 @@
     <style include="shared-styles">
       :host {
         display: block;
+        box-sizing: border-box;
         background: var(--lumo-shade-5pct);
-        padding: 12px 24px;
-        width: 250px;
+        padding: var(--lumo-space-wide-l);
+        width: 300px;
       }
 
       :host([phone]) {
@@ -27,27 +28,22 @@
         width: auto;
       }
 
-      #container {
+      .container {
         display: flex;
         flex-direction: column;
       }
 
-      #horizontal {
-        display: none;
-      }
-
-      #toolbar {
-        display: block;
-      }
-
-      #total {
+      .total {
         font-weight: 500;
         font-size: 18px;
         line-height: 1.4;
-        padding-bottom: 30px;
       }
 
-      #total .sum {
+      .total[hidden] {
+        display: none;
+      }
+
+      .total .sum {
         display: block;
         text-align: center;
         padding: 40px 0;
@@ -55,33 +51,9 @@
         font-weight: 300;
         color: var(--lumo-body-text-color);
       }
-
-      #total:not([hidden]) {
-        display: block;
-      }
-
-      @media (max-width: 1124px) {
-        #horizontal {
-          display: flex;
-        }
-
-        #total {
-          flex: 1;
-          margin-left: 16px;
-        }
-
-        #total .sum {
-          display: block;
-          text-align: center;
-          font-weight: 200;
-          font-size: 32px;
-          line-height: 100px;
-        }
-      }
-
     </style>
-    <div id="container">
-      <div id="total" hidden="[[tablet]]">
+    <div class="container">
+      <div class="total" hidden="[[tablet]]">
         <div class="section-title">To be reimbursed</div>
         <span class="sum">$[[totalOwed]]</span>
       </div>

--- a/src/icons.html
+++ b/src/icons.html
@@ -1,0 +1,11 @@
+<link rel="import" href="../bower_components/iron-iconset-svg/iron-iconset-svg.html">
+
+<iron-iconset-svg size="24" name="expense-manager">
+  <svg>
+    <defs>
+      <g id="add"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"></path></g>
+      <g id="close"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path></g>
+      <g id="filters"><path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"></path></g>
+    </defs>
+  </svg>
+</iron-iconset-svg>

--- a/src/info-dialog.html
+++ b/src/info-dialog.html
@@ -7,40 +7,34 @@
     <vaadin-dialog id="dialog" no-close-on-esc no-close-on-outside-click opened="[[open]]">
       <template>
         <style>
-          p {
-            font-size: 14px;
+          [part~="content"] {
+            padding: var(--lumo-space-l);
           }
 
           a {
-            text-decoration: none;
+            color: var(--lumo-primary-text-color);
           }
         </style>
 
         <h2>Welcome to Expense Manager</h2>
 
-        <div class="dialog-body">
-          <div class="instructions">
+        <p>
+          This is a sample Progressive Web App.
+        </p>
+        <p>
+          Try adding it to your home screen and using it offline.
+        </p>
+        <p>
+          This demo is built using <a tabindex="-1" href="https://www.polymer-project.org" target="_blank" rel="noopener">Polymer</a>
+          and <a tabindex="-1" href="https://vaadin.com/elements" target="_blank" rel="noopener">Vaadin Elements</a>.
+          <br>
+          You can find the source code and fork the project on <a tabindex="-1" href="https://github.com/vaadin/expense-manager-demo" rel="noopener">GitHub</a>.
+        </p>
 
-            <div class="text">
-              <p>
-                This is a sample Progressive Web App.
-              </p>
-              <p>
-                Try adding it to your home screen and using it offline.
-              </p>
-            </div>
-          </div>
-          <div class="about">
-            <p>
-              This demo is built using <a tabindex="-1" href="https://www.polymer-project.org" target="_blank">Polymer</a><br>
-              and <a tabindex="-1" href="https://vaadin.com/elements" target="_blank">Vaadin Elements</a>.
-              You can find the source code and fork the project on <a tabindex="-1" href="https://github.com/vaadin/expense-manager-demo">GitHub</a>.
-            </p>
-          </div>
-        </div>
         <div class="buttons">
-          <vaadin-button id="close-button" theme="primary" on-click="_close">Got it!</vaadin-button>
+          <vaadin-button theme="primary" on-click="_close">Got it!</vaadin-button>
         </div>
+
       </template>
     </vaadin-dialog>
 

--- a/src/login-page.html
+++ b/src/login-page.html
@@ -8,12 +8,10 @@
 <link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
 <link rel="import" href="data/store.html">
 
-
 <dom-module id="login-page">
   <template>
     <style include="lumo-color">
-       :host {
-        background: var(--lumo-base-color);
+      :host {
         min-height: 400px;
       }
 
@@ -21,10 +19,6 @@
         margin: 20px 0 0;
         padding-left: 30px;
         padding-right: 30px;
-      }
-
-      .error-message {
-        color: red;
       }
 
       .header {
@@ -46,10 +40,9 @@
       }
 
       .header h1 {
-        color: var(--lumo-primary-text-color);
         font-size: var(--lumo-font-size-xxl);
         font-weight: 300;
-        margin: 0 auto 16px;
+        margin: 0 auto var(--lumo-space-m);
         width: 300px;
       }
 
@@ -74,15 +67,14 @@
         align-items: center;
         position: absolute;
         bottom: 0;
-        color: var(--lumo-primary-text-color);
       }
 
       #footer a {
         text-decoration: none;
         color: var(--lumo-link-color);
       }
-
     </style>
+
     <iron-a11y-keys keys="enter" on-keys-pressed="_logIn"></iron-a11y-keys>
     <div id="header" class="header">
       <h1>Expense Manager</h1>

--- a/src/login-page.html
+++ b/src/login-page.html
@@ -46,7 +46,7 @@
       }
 
       .header h1 {
-        color: var(--text-primary-color);
+        color: var(--lumo-primary-text-color);
         font-size: var(--lumo-font-size-xxl);
         font-weight: 300;
         margin: 0 auto 16px;
@@ -74,7 +74,7 @@
         align-items: center;
         position: absolute;
         bottom: 0;
-        color: var(--text-primary-color);
+        color: var(--lumo-primary-text-color);
       }
 
       #footer a {

--- a/src/overview-page.html
+++ b/src/overview-page.html
@@ -49,6 +49,7 @@
         flex: 1;
       }
 
+<<<<<<< HEAD
       #sync {
         color: var(--light-primary-color);
         margin-left: 8px;
@@ -65,6 +66,25 @@
           transform: rotate(-360deg);
         }
       }
+=======
+      vaadin-button {
+        margin: 0 var(--lumo-space-s);
+        color: var(--lumo-primary-contrast-color);
+        text-transform: uppercase;
+      }
+
+      @media (max-width: 900px) {
+        app-toolbar {
+          --app-toolbar-content: {
+            padding: 0 6px 0 16px;
+          }
+        }
+        app-toolbar h1 {
+          font-size: 20px;
+        }
+      }
+
+>>>>>>> Cleanup styles, replace paper-icon-button, use custom iconset
     </style>
 
     <app-header-layout fullbleed>

--- a/src/overview-page.html
+++ b/src/overview-page.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/polymer/lib/mixins/gesture-event-listeners.html">
-<link rel="import" href="../bower_components/vaadin-button/vaadin-button.html">
 <link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
 <link rel="import" href="../bower_components/app-layout/app-header-layout/app-header-layout.html">
 <link rel="import" href="../bower_components/app-layout/app-header/app-header.html">
@@ -29,12 +28,12 @@
         height: 0.001px;
       }
 
-      #filters-toolbar[phone] {
+      filters-toolbar[phone] {
         width: auto;
         box-shadow: var(--lumo-shade-50pct) 0 -10px 6px -10px inset;
       }
 
-      #filters-toolbar {
+      filters-toolbar {
         width: 300px;
         box-shadow: inset -4px 0 16px -9px var(--lumo-shade-50pct);
       }
@@ -45,46 +44,9 @@
         }
       }
 
-      #content-panel {
+      content-panel {
         flex: 1;
       }
-
-<<<<<<< HEAD
-      #sync {
-        color: var(--light-primary-color);
-        margin-left: 8px;
-        animation: spin 0.8s linear infinite;
-      }
-
-      #sync[hidden] {
-        display: none;
-        animation: none;
-      }
-
-      @keyframes spin {
-        100% {
-          transform: rotate(-360deg);
-        }
-      }
-=======
-      vaadin-button {
-        margin: 0 var(--lumo-space-s);
-        color: var(--lumo-primary-contrast-color);
-        text-transform: uppercase;
-      }
-
-      @media (max-width: 900px) {
-        app-toolbar {
-          --app-toolbar-content: {
-            padding: 0 6px 0 16px;
-          }
-        }
-        app-toolbar h1 {
-          font-size: 20px;
-        }
-      }
-
->>>>>>> Cleanup styles, replace paper-icon-button, use custom iconset
     </style>
 
     <app-header-layout fullbleed>
@@ -93,8 +55,8 @@
       </app-header>
 
       <div class="content" phone$="[[_phone]]" tablet$="[[_tablet]]">
-        <filters-toolbar phone="[[_phone]]" tablet="[[_tablet]]" id="filters-toolbar"></filters-toolbar>
-        <content-panel phone="[[_phone]]" tablet="[[_tablet]]" id="content-panel"></content-panel>
+        <filters-toolbar phone="[[_phone]]" tablet="[[_tablet]]"></filters-toolbar>
+        <content-panel phone="[[_phone]]" tablet="[[_tablet]]"></content-panel>
       </div>
     </app-header-layout>
 

--- a/src/search-filters.html
+++ b/src/search-filters.html
@@ -17,7 +17,7 @@
     <style include="shared-styles">
       :host {
         display: block;
-        padding: 0 24px;
+        padding: var(--lumo-space-wide-l);
         width: inherit;
         overflow: auto;
         -webkit-overflow-scrolling: touch;
@@ -25,6 +25,7 @@
 
       :host([phone]) {
         width: auto;
+        padding: 0 var(--lumo-space-m);
       }
 
       :host([phone]) .filters {
@@ -70,7 +71,7 @@
     <div class="filters">
       <div class="title section-title" hidden="[[phone]]">
         <span>Filter Expenses</span>
-        <vaadin-button on-click="_clearFilters" theme="tertiary-inline">Clear Filters</vaadin-button>
+        <vaadin-button on-click="_clearFilters" theme="tertiary-inline small">Clear Filters</vaadin-button>
       </div>
       <vaadin-date-picker label="From" value="{{filters.start}}" max="[[filters.end]]"></vaadin-date-picker>
       <vaadin-date-picker label="To" value="{{filters.end}}" min="[[filters.start]]"></vaadin-date-picker>

--- a/src/search-filters.html
+++ b/src/search-filters.html
@@ -35,41 +35,10 @@
         display: flex;
       }
 
-      #buttons:not([hidden]) {
+      .buttons:not([hidden]) {
         display: flex;
-      }
-
-      #done-button {
-        margin-left: auto;
-      }
-
-      .col {
-        width: 100%;
-        box-sizing: border-box;
-      }
-
-      .col.total,
-      .col.date {
-        display: flex;
-        align-items: flex-end;
-      }
-
-      .col span:not(.caption) {
-        padding: 0 4px 12px;
-        color: rgba(0, 0, 0, 0.3);
-      }
-
-      .date span:not(.caption) {
-        padding: 0 4px 4px;
-      }
-
-      .date vaadin-date-picker {
-        display: block;
-        flex: 1;
-      }
-
-      .col.total vaadin-text-field {
-        flex: 1;
+        justify-content: space-between;
+        margin-top: var(--lumo-space-l);
       }
 
       .filters {
@@ -78,62 +47,45 @@
         padding-bottom: var(--lumo-space-m);
       }
 
-      .checkboxes {
-        display: inline-block;
-        margin-left: 8px;
-      }
-
-      .checkboxes>vaadin-checkbox {
-        margin-right: 8px;
-      }
-
-      .title>span:first-child {
-        flex: 1;
-      }
-
       .row {
         display: flex;
         align-items: baseline;
       }
 
       .row vaadin-text-field {
-        min-width: 0px;
+        min-width: 0;
         flex: auto;
       }
 
       .row .delimiter {
-        padding: 0 10px;
+        padding: 0 var(--lumo-space-s);
       }
 
       .title {
+        justify-content: space-between;
         align-items: baseline;
       }
-
-      #buttons {
-        margin-top: 32px;
-      }
-
     </style>
 
     <div class="filters">
       <div class="title section-title" hidden="[[phone]]">
         <span>Filter Expenses</span>
-        <vaadin-button class="clear-button" on-tap="_clearFilters" theme="tertiary-inline">Clear Filters</vaadin-button>
+        <vaadin-button on-click="_clearFilters" theme="tertiary-inline">Clear Filters</vaadin-button>
       </div>
-      <vaadin-date-picker id="from" auto-validate label="From" value="{{filters.start}}" max="[[filters.end]]"></vaadin-date-picker>
-      <vaadin-date-picker id="to" auto-validate label="To" value="{{filters.end}}" min="[[filters.start]]"></vaadin-date-picker>
+      <vaadin-date-picker label="From" value="{{filters.start}}" max="[[filters.end]]"></vaadin-date-picker>
+      <vaadin-date-picker label="To" value="{{filters.end}}" min="[[filters.start]]"></vaadin-date-picker>
       <div class="row">
-        <vaadin-text-field label="Min" value="{{filters.min}}" type="number" step="any">
+        <vaadin-text-field label="Min" value="{{filters.min}}" pattern="[0-9]+">
           <div slot="prefix">$</div>
         </vaadin-text-field>
         <span class="delimiter">–</span>
-        <vaadin-text-field label="Max" value="{{filters.max}}" type="number" step="any"></vaadin-text-field>
+        <vaadin-text-field label="Max" value="{{filters.max}}" pattern="[0-9]+"></vaadin-text-field>
       </div>
       <vaadin-combo-box label="Merchant" items="{{merchants}}" value="{{filters.merchant}}"></vaadin-combo-box>
       <option-group caption="Status" value="{{filters.status}}" items="[[statusOptions]]" label-path="label" value-path="name"></option-group>
-      <div id="buttons" hidden="[[!phone]]">
-        <vaadin-button class="clear-button" on-tap="_clearFilters" theme="tertiary">Clear Filters</vaadin-button>
-        <vaadin-button id="done-button" on-tap="_hideFilters">Done</vaadin-button>
+      <div class="buttons" hidden="[[!phone]]">
+        <vaadin-button on-click="_clearFilters" theme="tertiary">Clear Filters</vaadin-button>
+        <vaadin-button on-click="_hideFilters">Done</vaadin-button>
       </div>
     </div>
   </template>

--- a/src/shared-styles.html
+++ b/src/shared-styles.html
@@ -18,3 +18,17 @@
     </style>
   </template>
 </dom-module>
+
+<dom-module id="dialog-styles" theme-for="vaadin-dialog-overlay">
+  <template>
+    <style include="lumo-typography">
+      h2 {
+        margin-top: 0;
+      }
+
+      .buttons {
+        margin-top: var(--lumo-space-l);
+      }
+    </style>
+  </template>
+</dom-module>

--- a/src/shared-styles.html
+++ b/src/shared-styles.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
+<link rel="import" href="../bower_components/vaadin-lumo-styles/sizing.html">
 <link rel="import" href="../bower_components/vaadin-lumo-styles/spacing.html">
 <link rel="import" href="../bower_components/vaadin-lumo-styles/typography.html">
 
@@ -6,13 +7,12 @@
   <template>
     <style>
       .section-title {
+        min-height: var(--lumo-size-s);
+        margin: var(--lumo-space-s) 0 var(--lumo-space-m);
         font-weight: 400;
         font-size: var(--lumo-font-size-xs);
+        line-height: var(--lumo-line-height-m);
         border-bottom: 1px solid var(--lumo-shade-20pct);
-        padding-top: 14px;
-        padding-bottom: 6px;
-        margin-bottom: 18px;
-        margin-top: var(--lumo-space-xs);
         color: var(--lumo-secondary-text-color);
       }
     </style>


### PR DESCRIPTION
Connected to #59 

- replace `paper-icon-button`
- adjust styles for dialogs
- replace `iron-icons` import with custom iconset
- cleanup unused styles
- add `stylelint` and fix some warnings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/expense-manager-demo/78)
<!-- Reviewable:end -->
