### PR TITLE
Simplify buttons, get rid of paper-styles

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "iron-iconset-svg": "polymerelements/iron-iconset-svg#^2.0.0",
     "iron-pages": "polymerelements/iron-pages#^2.0.0",
     "iron-media-query": "polymerelements/iron-media-query#^2.0.0",
-    "paper-fab": "polymerelements/paper-fab#^2.0.0",
+    "paper-icon-button": "polymerelements/paper-icon-button#^2.0.0",
     "polymer-redux": "^1.0.3"
   },
   "devDependencies": {

--- a/src/expense-editor.html
+++ b/src/expense-editor.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/iron-a11y-keys/iron-a11y-keys.html">
-<link rel="import" href="../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../bower_components/vaadin-button/vaadin-button.html">
 <link rel="import" href="../bower_components/vaadin-combo-box/vaadin-combo-box.html">
 <link rel="import" href="../bower_components/vaadin-date-picker/vaadin-date-picker.html">
@@ -9,7 +8,6 @@
 <link rel="import" href="../bower_components/vaadin-upload/vaadin-upload.html">
 
 <link rel="import" href="data/store.html">
-<link rel="import" href="icons.html">
 
 <dom-module id="expense-editor">
   <template>
@@ -18,16 +16,6 @@
         <style>
           [part~="content"] {
             padding: var(--lumo-space-l);
-          }
-
-          .header {
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-start;
-          }
-
-          .close-button {
-            margin: 0;
           }
 
           .wrapper {
@@ -69,12 +57,7 @@
           }
         </style>
 
-        <div class="header">
-          <h2>[[_getCaption(_expense)]]</h2>
-          <vaadin-button on-click="close" theme="icon" class="close-button">
-            <iron-icon icon="expense-manager:close"></iron-icon>
-          </vaadin-button>
-        </div>
+        <h2>[[_getCaption(_expense)]]</h2>
 
         <div class="wrapper">
           <div id="form">

--- a/src/expenses-list.html
+++ b/src/expenses-list.html
@@ -27,7 +27,7 @@
         z-index: 1;
         background: var(--lumo-error-color);
         color: var(--lumo-error-contrast-color);
-        box-shadow: var(--lumo-box-shadow-s);
+        box-shadow: var(--lumo-box-shadow-m);
         border-radius: 50%;
       }
 

--- a/src/expenses-list.html
+++ b/src/expenses-list.html
@@ -1,7 +1,10 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../bower_components/vaadin-grid/vaadin-grid.html">
 <link rel="import" href="../bower_components/vaadin-grid/vaadin-grid-sorter.html">
-<link rel="import" href="../bower_components/paper-fab/paper-fab.html">
+<link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
+<link rel="import" href="../bower_components/vaadin-lumo-styles/sizing.html">
+<link rel="import" href="../bower_components/paper-icon-button/paper-icon-button-light.html">
 <link rel="import" href="date-helpers.html">
 <link rel="import" href="data/store.html">
 <link rel="import" href="icons.html">
@@ -9,19 +12,23 @@
 <dom-module id="expenses-list">
   <template>
     <style>
-       :host {
+      :host {
         position: relative;
         display: flex;
         flex-direction: column;
-        background: #fff;
       }
 
       #add-button {
         position: absolute;
+        height: var(--lumo-size-xl);
+        width: var(--lumo-size-xl);
         right: 32px;
         bottom: 32px;
         z-index: 1;
-        --paper-fab-background: var(--lumo-error-color);
+        background: var(--lumo-error-color);
+        color: var(--lumo-error-contrast-color);
+        box-shadow: var(--lumo-box-shadow-s);
+        border-radius: 50%;
       }
 
       #expenses {
@@ -61,7 +68,6 @@
       vaadin-grid#expenses .comment {
         text-overflow: ellipsis;
       }
-
     </style>
 
     <vaadin-grid items="[[expenses]]" id="expenses" active-item="{{activeItem}}">
@@ -132,7 +138,13 @@
       </vaadin-grid-column>
 
     </vaadin-grid>
-    <paper-fab icon="expense-manager:add" on-click="_showExpenseEditor" id="add-button"></paper-fab>
+
+    <paper-icon-button-light on-click="_showExpenseEditor" id="add-button">
+      <button>
+        <iron-icon icon="expense-manager:add"></iron-icon>
+      </button>
+    </paper-icon-button-light>
+
   </template>
   <script>
     (function() {

--- a/src/icons.html
+++ b/src/icons.html
@@ -4,7 +4,6 @@
   <svg>
     <defs>
       <g id="add"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"></path></g>
-      <g id="close"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path></g>
       <g id="filters"><path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"></path></g>
     </defs>
   </svg>


### PR DESCRIPTION
- Use `paper-icon-button-light` instead of `paper-fab`. This saves us 3 Kb of the bundle size and eliminates `paper-styles` dependency with a bunch of unused CSS variables. 
- Remove "Close" icon button in the Editor dialog. There is "Cancel" button already, adding another one seems unnecessary, and produces inconsistent UX (the Info dialog does not have it)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/expense-manager-demo/80)
<!-- Reviewable:end -->
