### PR TITLE
Fix login page layout. Prevent layout jump

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
       flex-direction: column;
       margin: 0;
       height: 100%;
-      background: #fff;
-      color: #000;
+      background: hsl(214, 35%, 21%);
+      color: #fff;
       font-family: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", Ubuntu, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
       -webkit-tap-highlight-color: transparent;
       -webkit-font-smoothing: antialiased;

--- a/src/filters-toolbar.html
+++ b/src/filters-toolbar.html
@@ -11,7 +11,7 @@
 
 <dom-module id="filters-toolbar">
   <template>
-    <style include="lumo-color">
+    <style include="lumo-color lumo-typography">
       :host {
         display: flex;
         -webkit-user-select: none;
@@ -19,6 +19,7 @@
         -ms-user-select: none;
         user-select: none;
         background: var(--lumo-shade-5pct);
+        color: var(--lumo-body-text-color);
         position: relative;
         z-index: 2;
       }

--- a/src/filters-toolbar.html
+++ b/src/filters-toolbar.html
@@ -18,7 +18,8 @@
         -moz-user-select: none;
         -ms-user-select: none;
         user-select: none;
-        background: var(--lumo-shade-5pct);
+        background-color: var(--lumo-base-color);
+        background-image: linear-gradient(var(--lumo-shade-5pct) 0%, var(--lumo-shade-5pct) 100%);
         color: var(--lumo-body-text-color);
         position: relative;
         z-index: 2;

--- a/src/history-panel.html
+++ b/src/history-panel.html
@@ -11,13 +11,14 @@
 
 <dom-module id="history-panel">
   <template>
-    <style include="shared-styles">
+    <style include="shared-styles lumo-typography lumo-color">
       :host {
         display: block;
         box-sizing: border-box;
         background: var(--lumo-shade-5pct);
         padding: var(--lumo-space-wide-l);
         width: 300px;
+        color: var(--lumo-body-text-color);
       }
 
       :host([phone]) {
@@ -35,7 +36,7 @@
 
       .total {
         font-weight: 500;
-        font-size: 18px;
+        font-size: var(--lumo-font-size-l);
         line-height: 1.4;
       }
 
@@ -49,7 +50,6 @@
         padding: 40px 0;
         font-size: 32px;
         font-weight: 300;
-        color: var(--lumo-body-text-color);
       }
     </style>
     <div class="container">

--- a/src/history-panel.html
+++ b/src/history-panel.html
@@ -15,7 +15,8 @@
       :host {
         display: block;
         box-sizing: border-box;
-        background: var(--lumo-shade-5pct);
+        background-color: var(--lumo-base-color);
+        background-image: linear-gradient(var(--lumo-shade-5pct) 0%, var(--lumo-shade-5pct) 100%);
         padding: var(--lumo-space-wide-l);
         width: 300px;
         color: var(--lumo-body-text-color);

--- a/src/login-page.html
+++ b/src/login-page.html
@@ -17,39 +17,40 @@
       }
 
       .wrapper {
+        height: 100%;
         display: flex;
         flex-direction: column;
-        justify-content: center;
-        height: calc(100% - var(--lumo-size-l));
         min-height: 360px;
       }
 
-      vaadin-button {
-        margin-top: var(--lumo-space-l);
-      }
-
-      .header::after {
-        display: block;
-        content: "";
-        width: 100%;
+      .header {
+        margin-top: auto;
         border-bottom: 4px solid var(--lumo-primary-color-50pct);
       }
 
       .header h1 {
+        margin: var(--lumo-space-m) auto;
         font-size: var(--lumo-font-size-xxl);
         font-weight: 300;
-        margin: var(--lumo-space-m) auto;
+      }
+
+      .header h1,
+      .login {
         width: 300px;
       }
 
       .login {
-        width: 300px;
-        margin: var(--lumo-space-m) auto;
+        padding-bottom: var(--lumo-space-m);
+        margin: var(--lumo-space-m) auto auto;
       }
 
       .login vaadin-text-field,
       .login vaadin-password-field {
         width: 100%;
+      }
+
+      vaadin-button {
+        margin-top: var(--lumo-space-l);
       }
 
       .footer {
@@ -76,14 +77,14 @@
         <vaadin-password-field value="{{password}}" label="Password" name="password"></vaadin-password-field>
         <vaadin-button theme="primary large" on-click="_logIn">Login</vaadin-button>
       </div>
-    </div>
-    <div class="footer">
-      <span class="fork-me">
-        Fork me on <a href="https://github.com/vaadin/expense-manager-demo">GitHub</a>
-      </span>
-      <span class="built-with">
-        Built with <a href="https://vaadin.com/elements">Vaadin Elements</a>
-      </span>
+      <div class="footer">
+        <span class="fork-me">
+          Fork me on <a href="https://github.com/vaadin/expense-manager-demo">GitHub</a>
+        </span>
+        <span class="built-with">
+          Built with <a href="https://vaadin.com/elements">Vaadin Elements</a>
+        </span>
+      </div>
     </div>
   </template>
 

--- a/src/login-page.html
+++ b/src/login-page.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../bower_components/iron-a11y-keys/iron-a11y-keys.html">
 <link rel="import" href="../bower_components/vaadin-button/vaadin-button.html">
 <link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
+<link rel="import" href="../bower_components/vaadin-lumo-styles/typography.html">
 <link rel="import" href="../bower_components/vaadin-text-field/vaadin-text-field.html">
 <link rel="import" href="../bower_components/vaadin-text-field/vaadin-password-field.html">
 
@@ -9,45 +10,41 @@
 
 <dom-module id="login-page">
   <template>
-    <style include="lumo-color">
+    <style include="lumo-color lumo-typography">
       :host {
-        min-height: 400px;
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
       }
 
-      #login-button {
-        margin: 20px 0 0;
-        padding-left: 30px;
-        padding-right: 30px;
-      }
-
-      .header {
-        height: 36%;
+      .wrapper {
         display: flex;
         flex-direction: column;
-        flex: 1;
-        justify-content: flex-end;
-        margin: 0 !important;
-        padding: 0 !important;
+        justify-content: center;
+        height: calc(100% - var(--lumo-size-l));
+        min-height: 360px;
+      }
+
+      vaadin-button {
+        margin-top: var(--lumo-space-l);
       }
 
       .header::after {
+        display: block;
         content: "";
-        position: absolute;
         width: 100%;
-        top: 36%;
         border-bottom: 4px solid var(--lumo-primary-color-50pct);
       }
 
       .header h1 {
         font-size: var(--lumo-font-size-xxl);
         font-weight: 300;
-        margin: 0 auto var(--lumo-space-m);
+        margin: var(--lumo-space-m) auto;
         width: 300px;
       }
 
       .login {
         width: 300px;
-        margin: 16px auto;
+        margin: var(--lumo-space-m) auto;
       }
 
       .login vaadin-text-field,
@@ -55,35 +52,32 @@
         width: 100%;
       }
 
-      #footer {
-        font-size: var(--lumo-font-size-s);
-        background: var(--lumo-shade-20pct);
-        padding: 14px 26px;
+      .footer {
         width: 100%;
+        height: var(--lumo-size-l);
         display: flex;
+        padding: var(--lumo-space-wide-l);
         justify-content: space-between;
         box-sizing: border-box;
         align-items: center;
-        position: absolute;
-        bottom: 0;
-      }
-
-      #footer a {
-        text-decoration: none;
-        color: var(--lumo-link-color);
+        font-size: var(--lumo-font-size-s);
+        background: var(--lumo-shade-20pct);
       }
     </style>
 
     <iron-a11y-keys keys="enter" on-keys-pressed="_logIn"></iron-a11y-keys>
-    <div id="header" class="header">
-      <h1>Expense Manager</h1>
+
+    <div class="wrapper">
+      <div class="header">
+        <h1>Expense Manager</h1>
+      </div>
+      <div class="login">
+        <vaadin-text-field value="{{username}}" label="Username" name="username"></vaadin-text-field>
+        <vaadin-password-field value="{{password}}" label="Password" name="password"></vaadin-password-field>
+        <vaadin-button theme="primary large" on-click="_logIn">Login</vaadin-button>
+      </div>
     </div>
-    <div class="login">
-      <vaadin-text-field value={{username}} label="Username" name="username"></vaadin-text-field>
-      <vaadin-password-field value="{{password}}" label="Password" name="password"></vaadin-password-field>
-      <vaadin-button theme="primary" id="login-button" on-click="_logIn">Login</vaadin-button>
-    </div>
-    <div id="footer">
+    <div class="footer">
       <span class="fork-me">
         Fork me on <a href="https://github.com/vaadin/expense-manager-demo">GitHub</a>
       </span>

--- a/src/login-page.html
+++ b/src/login-page.html
@@ -10,7 +10,7 @@
 
 <dom-module id="login-page">
   <template>
-    <style include="lumo-color lumo-typography">
+    <style include="lumo-color-legacy lumo-typography">
       :host {
         overflow: auto;
         -webkit-overflow-scrolling: touch;

--- a/src/nav-bar.html
+++ b/src/nav-bar.html
@@ -30,10 +30,6 @@
         text-transform: uppercase;
         flex-shrink: 0;
       }
-
-      vaadin-button:first-of-type {
-        margin-left: auto;
-      }
     </style>
 
     <h1>Expense Manager</h1>

--- a/src/nav-bar.html
+++ b/src/nav-bar.html
@@ -12,7 +12,7 @@
     <style include="lumo-color">
       :host {
         display: flex;
-        justify-content: space-between;
+        justify-content: flex-end;
         align-items: center;
         box-sizing: border-box;
         width: 100%;
@@ -28,8 +28,8 @@
 
       vaadin-button {
         margin-left: var(--lumo-space-m);
-        flex: none;
         text-transform: uppercase;
+        flex-shrink: 0;
       }
     </style>
 

--- a/src/nav-bar.html
+++ b/src/nav-bar.html
@@ -9,10 +9,9 @@
 
 <dom-module id="nav-bar">
   <template>
-    <style include="lumo-color">
+    <style include="lumo-color-legacy">
       :host {
         display: flex;
-        justify-content: flex-end;
         align-items: center;
         box-sizing: border-box;
         width: 100%;
@@ -30,6 +29,10 @@
         margin-left: var(--lumo-space-m);
         text-transform: uppercase;
         flex-shrink: 0;
+      }
+
+      vaadin-button:first-of-type {
+        margin-left: auto;
       }
     </style>
 

--- a/src/option-group.html
+++ b/src/option-group.html
@@ -6,9 +6,10 @@
 
 <dom-module id="option-group">
   <template>
-    <style>
+    <style include="lumo-color lumo-typography">
       :host {
         display: block;
+        color: var(--lumo-body-text-color);
       }
 
       .caption {

--- a/src/overview-page.html
+++ b/src/overview-page.html
@@ -26,6 +26,7 @@
         display: flex;
         flex: auto;
         height: 0.001px;
+        background: var(--lumo-base-color);
       }
 
       filters-toolbar[phone] {


### PR DESCRIPTION
- removed the `height: 36%` causing problems on mobile devices
- updated login page layout to use flex box
- changed `body` background back to dark one,to prevent background flash when switching pages
- added `background` and `color` for some elements previously inherited those properties from body
- changed `nav-bar` to prevent noticeable layout jump when switching from login page, it appears that `justify-content: flex-end` works better in this case

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/expense-manager-demo/81)
<!-- Reviewable:end -->