### PR TITLE
Reduce the size of the receipt to meet localStorage limitations

### DIFF
--- a/src/expense-editor.html
+++ b/src/expense-editor.html
@@ -284,7 +284,7 @@
           const file = e.detail.file;
           this._resizeImage(file, data => {
             this.set('_expense.receipt', data);
-          }, 'image/jpeg', 1000, 1000);
+          }, 'image/jpeg', 300, 300);
 
           this._getDialogChild('vaadin-upload').files = [];
         }


### PR DESCRIPTION
Fixes #100

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/expense-manager-demo/105)
<!-- Reviewable:end -->
